### PR TITLE
sevctl ok: Detect and use host arch's CPU generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Probes processor, sysfs, and KVM for AMD SEV, SEV-ES, and SEV-SNP related featur
 
 ```console
 $ sevctl ok {sev, es, snp}   // Probes support for the generation specified.
-$ sevctl ok                  // Probes for SEV, SEV-ES, and SEV-SNP support.
+$ sevctl ok                  // Probes support for the host hardware's generation.
 ```
 
 ### provision

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@
 //!
 //! ```console
 //! $ sevctl ok {sev, es, snp}   // Probes support for the generation specified.
-//! $ sevctl ok                  // Probes for SEV, SEV-ES, and SEV-SNP support.
+//! $ sevctl ok                  // Probes support for the host hardware's generation.
 //! ```
 //!
 //! ## provision


### PR DESCRIPTION
When using sevctl ok without specifying a generation, allow the tool to determine the underlying processor's SEV generation and only include tests relevant to that specific generation.