### PR TITLE
Convert more enarx -> virtee references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,7 +473,7 @@ dependencies = [
 [[package]]
 name = "sev"
 version = "0.2.0"
-source = "git+https://github.com/enarx/sev.git?branch=main#c7a41d0a3d7cdb691a657274cf9f47938fe783b2"
+source = "git+https://github.com/virtee/sev.git?branch=main#c7a41d0a3d7cdb691a657274cf9f47938fe783b2"
 dependencies = [
  "bitfield",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.2.0"
 authors = ["The Enarx Project Developers"]
 edition = "2018"
 license = "Apache-2.0"
-homepage = "https://github.com/enarx/sevctl"
-repository = "https://github.com/enarx/sevctl"
+homepage = "https://github.com/virtee/sevctl"
+repository = "https://github.com/virtee/sevctl"
 description = "Administrative utility for AMD SEV"
 readme = "README.md"
 keywords = ["amd", "sev"]
@@ -15,14 +15,14 @@ rust-version = "1.51"
 
 [badges]
 # See https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section
-github = { repository = "enarx/sevctl", workflow = "test" }
-#github = { repository = "enarx/sevctl", workflow = "lint" }
+github = { repository = "virtee/sevctl", workflow = "test" }
+#github = { repository = "virtee/sevctl", workflow = "lint" }
 maintenance = { status = "actively-developed" }
-is-it-maintained-issue-resolution = { repository = "enarx/sevctl" }
-is-it-maintained-open-issues = { repository = "enarx/sevctl" }
+is-it-maintained-issue-resolution = { repository = "virtee/sevctl" }
+is-it-maintained-open-issues = { repository = "virtee/sevctl" }
 
 [dependencies]
-sev = { git = "https://github.com/enarx/sev.git", branch = "main", features = ["openssl"] }
+sev = { git = "https://github.com/virtee/sev.git", branch = "main", features = ["openssl"] }
 structopt = "0.3"
 codicon = "3.0"
 colorful = "0.2.1"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Workflow Status](https://github.com/enarx/sevctl/workflows/test/badge.svg)](https://github.com/enarx/sevctl/actions?query=workflow%3A%22test%22)
-[![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/enarx/sevctl.svg)](https://isitmaintained.com/project/enarx/sevctl "Average time to resolve an issue")
-[![Percentage of issues still open](https://isitmaintained.com/badge/open/enarx/sevctl.svg)](https://isitmaintained.com/project/enarx/sevctl "Percentage of issues still open")
+[![Workflow Status](https://github.com/virtee/sevctl/workflows/test/badge.svg)](https://github.com/virtee/sevctl/actions?query=workflow%3A%22test%22)
+[![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/virtee/sevctl.svg)](https://isitmaintained.com/project/virtee/sevctl "Average time to resolve an issue")
+[![Percentage of issues still open](https://isitmaintained.com/badge/open/virtee/sevctl.svg)](https://isitmaintained.com/project/virtee/sevctl "Percentage of issues still open")
 ![Maintenance](https://img.shields.io/badge/maintenance-activly--developed-brightgreen.svg)
 
 # sevctl


### PR DESCRIPTION
Cargo.* and README.md badges still point to enarx github.
Switch them to virtee
