### PR TITLE
ok: Shift result not mask

### DIFF
--- a/src/ok.rs
+++ b/src/ok.rs
@@ -246,7 +246,7 @@ fn collect_tests() -> Vec<Test> {
                             gen_mask: SEV_MASK,
                             run: Box::new(|| {
                                 let res = unsafe { x86_64::__cpuid(0x8000_001f) };
-                                let field = res.ebx & 0b1111_1100_0000 >> 6;
+                                let field = (res.ebx & 0b1111_1100_0000) >> 6;
 
                                 TestResult {
                                     name: "Physical address bit reduction",


### PR DESCRIPTION
A missing pair of brackets mean we end up shifting the mask not
the result of the mask.

Add the brackets:

Before:
[ PASS ]     - Physical address bit reduction: 47
[ PASS ]     - C-bit location: 47

After:
[ PASS ]     - Physical address bit reduction: 5
[ PASS ]     - C-bit location: 47

Signed-off-by: Dr. David Alan Gilbert <dgilbert@redhat.com>