### PR TITLE
Drop rust 1.51.0 and fix clippy nightly errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,6 @@ jobs:
           - nightly
           - beta
           - stable
-          - 1.51.0
         profile:
           - name: debug
           - name: release

--- a/src/http.rs
+++ b/src/http.rs
@@ -59,7 +59,7 @@ pub fn get(url: &str) -> Result<Response, Error> {
     let port = url.port_or_known_default().ok_or(Error::NoPort)?;
 
     let connector = TlsConnector::new().map_err(|e| Error::Tls(Box::new(e)))?;
-    let stream = TcpStream::connect(&format!("{}:{}", host, port)).map_err(Error::Io)?;
+    let stream = TcpStream::connect(format!("{}:{}", host, port)).map_err(Error::Io)?;
     let mut stream = connector
         .connect(host, stream)
         .map_err(|e| Error::Tls(Box::new(e)))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -541,7 +541,7 @@ mod verify {
     }
 
     fn ca_chain(filename: PathBuf) -> Result<ca::Chain> {
-        let mut file = File::open(&filename).context("unable to open CA certificate chain file")?;
+        let mut file = File::open(filename).context("unable to open CA certificate chain file")?;
         ca::Chain::decode(&mut file, ()).context("unable to decode chain")
     }
 }


### PR DESCRIPTION
* Drop 1.51.0 rust testing, like was done for sev crate
* Fix current `main` branch clippy errors with rust nightly