### PR TITLE
Update sev library to version 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97422ba48d7ffb66fd4d18130f72ab66f9bbbf791fb7a87b9291cdcfec437593"
+checksum = "b8f8dc9c1896e5f144ec5d07169bc29f39a047686d29585a91f30489abfaeb6b"
 dependencies = [
  "kvm-bindings",
  "libc",
@@ -576,10 +576,11 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343ca80f0f064f0f293a6066e81c2977e819e909b348634701ab8fe4304e7749"
+checksum = "a8c8ec2a5131be61bba9ffad92aead45bd27805c9701d265b7196d4914299b98"
 dependencies = [
+ "bincode",
  "bitfield",
  "bitflags",
  "codicon",
@@ -591,6 +592,7 @@ dependencies = [
  "serde-big-array",
  "serde_bytes",
  "static_assertions",
+ "uuid",
 ]
 
 [[package]]
@@ -758,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.1.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ is-it-maintained-issue-resolution = { repository = "virtee/sevctl" }
 is-it-maintained-open-issues = { repository = "virtee/sevctl" }
 
 [dependencies]
-sev = { version = "1.0.1", features = ["openssl"] }
+sev = { version = "1.1.0", features = ["openssl"] }
 serde = { version = "1.0", features = ["derive"] }
 # serde_json is just for the example, not required in general
 serde_json = "1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,10 @@ use structopt::StructOpt;
 use codicon::*;
 
 use ::sev::certs::*;
-use ::sev::firmware::host::{types::Status, Firmware, PlatformStatusFlags};
+use ::sev::firmware::host::{
+    types::{PlatformStatusFlags, Status},
+    Firmware,
+};
 use ::sev::Generation;
 
 use std::fs::File;


### PR DESCRIPTION
sev 1.1.0 is the latest version of the library.

Signed-off-by: Tyler Fanelli <tfanelli@redhat.com>