### PR TITLE
dependency: Enable vendored feature for openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,6 +375,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
+name = "openssl-src"
+version = "111.25.0+1.1.1t"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3173cd3626c43e3854b1b727422a276e568d9ec5fe8cec197822cf52cfb743d6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +392,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ libc = "0.2.126"
 native-tls = "0.2"
 url = "2.2"
 base64 = "0.13.0"
-openssl = "0.10"
+openssl = { version = "0.10", features = ["vendored"] }
 uuid = "1.1.2"
 anyhow = "1.0.57"
 log = "0.4"


### PR DESCRIPTION
To enable static building of the sevctl binary enable vendored feature of openssl.