### PR TITLE
measurement: fix pad calculation

### DIFF
--- a/src/measurement.rs
+++ b/src/measurement.rs
@@ -103,7 +103,7 @@ pub fn build_table(
     entry_size: usize,
 ) -> super::Result<Vec<u8>> {
     let mut table = build_entry(guid, payload, entry_size)?;
-    let pad = 16 - (table.len() % 16);
+    let pad = ((table.len() + 16 - 1) & !(16 - 1)) - table.len();
     table.extend(vec![0; pad]);
     Ok(table)
 }


### PR DESCRIPTION
The guest memory region must be 16 B aligned, but the current pad formula is invalid: it adds 16 bytes when a pad is not needed. It causes OVMF to fail, since the secret packet will overflow (while using `sevctl secret build ...` and 16 K secrets). This PR fixes it.