### PR TITLE
Add instruction for installing build-dependencies for RHEL and its compatible distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,4 +189,9 @@ sevctl.
 sudo apt install -y pkg-config libssl-dev asciidoctor
 ```
 
+### RHEL and its compatible distributions
+```console
+sudo dnf install -y gcc openssl-devel pkg-config perl perl-FindBin perl-File-Compare
+```
+
 License: Apache-2.0


### PR DESCRIPTION
This PR proposes to add instruction for installing build-dependencies for RHEL and its compatible distributions like Rocky Linux as well as existing instruction for Ubuntu.