### PR TITLE
Extended features for non-kvm hypervisor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,6 +996,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "proc-cpuinfo"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5e67580a7a844bd6db5fa32e0a6061c03e3aabe186233ed11b516605db6d69"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,6 +1341,7 @@ dependencies = [
  "log",
  "msru",
  "openssl",
+ "proc-cpuinfo",
  "proc-macro2",
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "sevctl"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "base64 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1327,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "sevctl"
-version = "0.6.3"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ env_logger = "0.8.4"
 proc-macro2 = "1.0.60"
 reqwest = "0.12.4"
 tokio = { version = "1.29.1", features = ["rt-multi-thread"] }
+proc-cpuinfo = "0.2.0"
 
 [dev-dependencies]
 tempfile = "3.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sevctl"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["The Enarx/VirTEE Project Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sevctl"
-version = "0.6.3"
+version = "0.6.2"
 authors = ["The Enarx/VirTEE Project Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,20 @@ struct Sevctl {
 #[allow(clippy::large_enum_variant)]
 #[derive(Subcommand)]
 enum SevctlCmd {
+    /// Add the cek certificate to a partial certificate chain returned by the PSP
+    Addcek {
+        /// Read SEV partial chain from specified file
+        #[arg(short, long, value_name = "crt", required = true)]
+        crt: PathBuf,
+
+        /// Id of the processor to get the CEK
+        #[arg(short, long, value_name = "id", required = true)]
+        id: String,
+
+        /// Output file
+        #[arg(long, value_name = "dst")]
+        dst: Option<PathBuf>,
+    },
     /// Export the SEV or entire certificate chain
     Export {
         /// Export the entire certificate chain? (SEV + CA chain)
@@ -251,6 +265,7 @@ fn main() -> Result<()> {
 
     let sevctl = Sevctl::parse();
     let status = match sevctl.cmd {
+        SevctlCmd::Addcek { crt, id, dst } => addcek::cmd(crt, id, dst ),
         SevctlCmd::Export { full, destination } => export::cmd(full, destination),
         SevctlCmd::Generate { cert, key } => generate::cmd(cert, key),
         SevctlCmd::Ok { gen } => ok::cmd(gen, sevctl.quiet),
@@ -551,5 +566,48 @@ mod provision {
             .context("failed to import the newly-signed PEK")?;
 
         Ok(())
+    }
+}
+
+
+
+mod addcek {
+
+    use std::{convert::TryFrom};
+
+    use super::*;
+
+    const CEK_SVC: &str = "https://kdsintf.amd.com/cek/id";
+
+    pub fn cmd(crt: PathBuf, id: String, dst: Option<PathBuf>) -> Result<()> {
+        let mut chain = sev_chain(crt)?;
+        let mut out = Cursor::new(Vec::new());
+
+        let url = format!("{}/{}", CEK_SVC, id);
+        let dst_path : PathBuf = match dst {
+            None => PathBuf::try_from("phd.bin")?,
+            Some(f) => f
+        };
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        chain.cek = rt.block_on(download(&url, Usage::CEK))?;
+
+        chain
+            .encode(&mut out, ())
+            .context("certificate chain encoding failed")?;
+
+        let mut file = File::create(dst_path).context("unable to create output file")?;
+
+        file.write_all(&out.into_inner())
+            .context("unable to write output file")?;
+
+        Ok(())
+    }
+
+    fn sev_chain(filename: PathBuf) -> Result<Chain> {
+        let mut file =
+            File::open(filename).context("unable to open SEV certificate chain file")?;
+
+        Chain::decode(&mut file, ()).context("unable to decode chain")
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,6 +98,13 @@ enum SevctlCmd {
         /// Path to the owner's OCA private key.
         #[arg(value_name = "key", required = true)]
         key: PathBuf,
+        /// Path to the PEK input file.
+        #[arg(short, long, value_name = "in_pek", required = false)]
+        in_pek: Option<PathBuf>,
+        
+        /// Path to PEK output file.
+        #[arg(short, long, value_name = "out_pek", required = false)]
+        out_pek: Option<PathBuf>,
     },
 
     /// Reset the SEV platform state
@@ -272,7 +279,7 @@ fn main() -> Result<()> {
         SevctlCmd::Measurement(option) => match option {
             measurement::MeasurementCmd::Build(args) => measurement::build_cmd(args),
         },
-        SevctlCmd::Provision { cert, key } => provision::cmd(cert, key),
+        SevctlCmd::Provision { cert, key, in_pek, out_pek } => provision::cmd(cert, key, in_pek, out_pek),
         SevctlCmd::Reset => reset::cmd(),
         SevctlCmd::Rotate => rotate::cmd(),
         SevctlCmd::Secret(option) => match option {
@@ -541,8 +548,9 @@ mod provision {
 
     use ::sev::certs::sev::{PrivateKey, Signer};
 
-    pub fn cmd(oca_path: PathBuf, prv_key_path: PathBuf) -> Result<()> {
-        let mut fw = firmware()?;
+    pub fn cmd(oca_path: PathBuf, prv_key_path: PathBuf, in_pek: Option<PathBuf>, out_pek: Option<PathBuf>) -> Result<()> {
+        let mut out = Cursor::new(Vec::new());
+       
         let cert = File::open(oca_path.clone())
             .context(format!("failed to open {}", oca_path.display()))
             .and_then(|mut f| Certificate::decode(&mut f, ()).context("failed to decode OCA"))?;
@@ -554,17 +562,38 @@ mod provision {
                     .context("failed to decode OCA private key")
             })?;
 
-        let mut pek = fw
-            .pek_csr()
-            .map_err(|e| anyhow::anyhow!(format!("{:?}", e)))
-            .context("cross signing request failed")?;
+        let mut pek = match in_pek {
+            None => {
+                let mut fw = firmware()?;
+                fw.pek_csr()
+                .map_err(|e| anyhow::anyhow!(format!("{:?}", e)))
+                .context("cross signing request failed")?
+            }
+            Some(f) => { let mut file =
+                File::open(f.clone()).context(format!("failed to open {}", f.display()))?;
+                Certificate::decode(&mut file, ()).context("Unable to decode certificate")?
+            }
+        };
+
         prv_key
             .sign(&mut pek)
             .context("failed to sign PEK with OCA private key")?;
-        fw.pek_cert_import(&pek, &cert)
-            .map_err(|e| anyhow::anyhow!(format!("{:?}", e)))
-            .context("failed to import the newly-signed PEK")?;
-
+        
+        match out_pek {
+            None => {
+                let mut fw = firmware()?;
+                fw.pek_cert_import(&pek, &cert)
+                    .map_err(|e| anyhow::anyhow!(format!("{:?}", e)))
+                    .context("failed to import the newly-signed PEK")?;
+            }
+            Some(f) => {
+                let mut file = File::create(f.clone()).context(format!("failed to open {}", f.display()))?;
+                pek.encode(&mut out, ()).context("Failed to write pek to output file")?;
+                file.write_all(&out.into_inner())
+                    .context("unable to write output file")?;
+            }
+        };
+         
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,13 @@ enum SevctlCmd {
         #[arg(value_name = "destination", required = true)]
         destination: PathBuf,
     },
+    
+    /// Get latest firmware
+    Firmware {
+        /// firmware output file path
+        #[arg(value_name = "out", required = true)]
+        out: PathBuf,
+    },
 
     /// Generate a new self-signed OCA certificate and key
     Generate {
@@ -173,7 +180,8 @@ enum SevctlCmd {
     Secret(secret::SecretCmd),
 }
 
-async fn download(url: &str, usage: Usage) -> Result<Certificate> {
+async fn download(url: &str) -> Result<Cursor<Vec<u8>>> {
+    
     let mut err_stack: Vec<anyhow::Error> = vec![];
 
     for attempt in 1..4 {
@@ -192,9 +200,7 @@ async fn download(url: &str, usage: Usage) -> Result<Certificate> {
             }
             Ok(rsp) => match rsp.bytes().await {
                 Ok(body) => {
-                    let out = Cursor::new(body.into_iter().collect::<Vec<u8>>());
-                    return Certificate::decode(out, ())
-                        .context(format!("failed to decode {} certificate", usage));
+                    return Ok(Cursor::new(body.into_iter().collect::<Vec<u8>>()));
                 }
                 Err(e) => return Err(anyhow::Error::new(e).context("failed to read response body")),
             },
@@ -217,14 +223,23 @@ async fn download(url: &str, usage: Usage) -> Result<Certificate> {
         anyhow::anyhow!(prev_attempts.join("; "))
             .context(format!("final http request failed: {}", e))
     })?;
+    
+    if !(rsp).status().is_success() {
+        return Err(anyhow::anyhow!(format!("Http request {}", rsp.status().as_u16())));
+    }
 
     match rsp.bytes().await {
         Ok(body) => {
-            let out = Cursor::new(body.into_iter().collect::<Vec<u8>>());
-            Certificate::decode(out, ()).context(format!("failed to decode {} certificate", usage))
-        }
+            return Ok(Cursor::new(body.into_iter().collect::<Vec<u8>>()));
+        },
         Err(e) => Err(anyhow::Error::new(e).context("failed to read response body")),
     }
+}
+    
+fn download_certificate(url: &str, usage: Usage) -> Result<Certificate> {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let out = rt.block_on(download(url))?;
+    return Certificate::decode(out, ()).context(format!("failed to decode {} certificate", usage))
 }
 
 fn firmware() -> Result<Firmware> {
@@ -252,8 +267,7 @@ fn chain() -> Result<Chain> {
         .context("error fetching identifier")?;
     let url = format!("{}/{}", CEK_SVC, id);
 
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    chain.cek = rt.block_on(download(&url, Usage::CEK))?;
+    chain.cek = download_certificate(&url, Usage::CEK)?;
 
     Ok(chain)
 }
@@ -274,6 +288,7 @@ fn main() -> Result<()> {
     let status = match sevctl.cmd {
         SevctlCmd::Addcek { crt, id, dst } => addcek::cmd(crt, id, dst ),
         SevctlCmd::Export { full, destination } => export::cmd(full, destination),
+        SevctlCmd::Firmware { out } => firmware::cmd(out),
         SevctlCmd::Generate { cert, key } => generate::cmd(cert, key),
         SevctlCmd::Ok { gen } => ok::cmd(gen, sevctl.quiet),
         SevctlCmd::Measurement(option) => match option {
@@ -614,19 +629,17 @@ mod addcek {
 
         let url = format!("{}/{}", CEK_SVC, id);
         let dst_path : PathBuf = match dst {
-            None => PathBuf::try_from("phd.bin")?,
+            None => PathBuf::try_from("pdh.bin")?,
             Some(f) => f
         };
 
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        chain.cek = rt.block_on(download(&url, Usage::CEK))?;
+        chain.cek = download_certificate(&url, Usage::CEK)?;
 
         chain
             .encode(&mut out, ())
             .context("certificate chain encoding failed")?;
 
         let mut file = File::create(dst_path).context("unable to create output file")?;
-
         file.write_all(&out.into_inner())
             .context("unable to write output file")?;
 
@@ -638,5 +651,62 @@ mod addcek {
             File::open(filename).context("unable to open SEV certificate chain file")?;
 
         Chain::decode(&mut file, ()).context("unable to decode chain")
+    }
+}
+
+//https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/amd/amd_sev_fam17h_model0xh.sbin
+
+
+mod firmware {
+    use super::*;
+    
+    use proc_cpuinfo::{CpuInfo};
+
+    const REPO: &str = "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/amd";
+
+    pub fn cmd(dst: PathBuf) -> Result<()> {
+        let cpu = CpuInfo::read()?;
+        let cpu_info = cpu.cpu(0).unwrap();
+        let url_specific = format!("{}/amd_sev_fam{:x}h_model{:x}h.sbin", REPO, 
+                    cpu_info.cpu_family().unwrap(),
+                    cpu_info.model().unwrap());
+        let url_family = format!("{}/amd_sev_fam{:x}h_model{:x}xh.sbin", REPO, 
+                    cpu_info.cpu_family().unwrap(),
+                    cpu_info.model().unwrap() / 16);
+        let url_generic = format!("{}/sev.fw", REPO);
+        //need to do it in reverse by ignoring stuff, firmware can be inexistant
+        
+        let mut file = File::create(dst).context("unable to create output file")?;
+        
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        
+        match rt.block_on(download(&url_specific)) {
+            Ok(out) => {
+                println!("Find specific firmware version");
+                file.write_all(&out.into_inner()).context("unable to write output file")?; return Ok(());
+            },
+            Err(_err) => {
+                println!("No specific firmware version");
+            }
+        }
+        match rt.block_on(download(&url_family)) {
+            Ok(out) => {
+                println!("Find family firmware version");
+                file.write_all(&out.into_inner()).context("unable to write output file")?; return Ok(());
+            },
+            Err(_err) => {
+                println!("No less firmware version, this should never happens");
+            }
+        }
+        match rt.block_on(download(&url_generic)) {
+            Ok(out) => {
+                println!("Find generic firmware version");
+                file.write_all(&out.into_inner()).context("unable to write output file")?; return Ok(());
+            },
+            Err(_err) => {
+                println!("No generic firmware, this should happens, amd doesn't provide generic version");
+            }
+        }
+        Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,12 +70,12 @@ enum SevctlCmd {
         #[arg(value_name = "destination", required = true)]
         destination: PathBuf,
     },
-    
+
     /// Get latest firmware
     Firmware {
         /// firmware output file path
-        #[arg(value_name = "out", required = true)]
-        out: PathBuf,
+        #[arg(short, long, value_name = "out", required = false)]
+        out: Option<PathBuf>,
     },
 
     /// Generate a new self-signed OCA certificate and key
@@ -108,7 +108,7 @@ enum SevctlCmd {
         /// Path to the PEK input file.
         #[arg(short, long, value_name = "in_pek", required = false)]
         in_pek: Option<PathBuf>,
-        
+
         /// Path to PEK output file.
         #[arg(short, long, value_name = "out_pek", required = false)]
         out_pek: Option<PathBuf>,
@@ -181,7 +181,6 @@ enum SevctlCmd {
 }
 
 async fn download(url: &str) -> Result<Cursor<Vec<u8>>> {
-    
     let mut err_stack: Vec<anyhow::Error> = vec![];
 
     for attempt in 1..4 {
@@ -223,23 +222,26 @@ async fn download(url: &str) -> Result<Cursor<Vec<u8>>> {
         anyhow::anyhow!(prev_attempts.join("; "))
             .context(format!("final http request failed: {}", e))
     })?;
-    
+
     if !(rsp).status().is_success() {
-        return Err(anyhow::anyhow!(format!("Http request {}", rsp.status().as_u16())));
+        return Err(anyhow::anyhow!(format!(
+            "Http request {}",
+            rsp.status().as_u16()
+        )));
     }
 
     match rsp.bytes().await {
         Ok(body) => {
             return Ok(Cursor::new(body.into_iter().collect::<Vec<u8>>()));
-        },
+        }
         Err(e) => Err(anyhow::Error::new(e).context("failed to read response body")),
     }
 }
-    
+
 fn download_certificate(url: &str, usage: Usage) -> Result<Certificate> {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let out = rt.block_on(download(url))?;
-    return Certificate::decode(out, ()).context(format!("failed to decode {} certificate", usage))
+    return Certificate::decode(out, ()).context(format!("failed to decode {} certificate", usage));
 }
 
 fn firmware() -> Result<Firmware> {
@@ -286,7 +288,7 @@ fn main() -> Result<()> {
 
     let sevctl = Sevctl::parse();
     let status = match sevctl.cmd {
-        SevctlCmd::Addcek { crt, id, dst } => addcek::cmd(crt, id, dst ),
+        SevctlCmd::Addcek { crt, id, dst } => addcek::cmd(crt, id, dst),
         SevctlCmd::Export { full, destination } => export::cmd(full, destination),
         SevctlCmd::Firmware { out } => firmware::cmd(out),
         SevctlCmd::Generate { cert, key } => generate::cmd(cert, key),
@@ -294,7 +296,12 @@ fn main() -> Result<()> {
         SevctlCmd::Measurement(option) => match option {
             measurement::MeasurementCmd::Build(args) => measurement::build_cmd(args),
         },
-        SevctlCmd::Provision { cert, key, in_pek, out_pek } => provision::cmd(cert, key, in_pek, out_pek),
+        SevctlCmd::Provision {
+            cert,
+            key,
+            in_pek,
+            out_pek,
+        } => provision::cmd(cert, key, in_pek, out_pek),
         SevctlCmd::Reset => reset::cmd(),
         SevctlCmd::Rotate => rotate::cmd(),
         SevctlCmd::Secret(option) => match option {
@@ -563,9 +570,14 @@ mod provision {
 
     use ::sev::certs::sev::{PrivateKey, Signer};
 
-    pub fn cmd(oca_path: PathBuf, prv_key_path: PathBuf, in_pek: Option<PathBuf>, out_pek: Option<PathBuf>) -> Result<()> {
+    pub fn cmd(
+        oca_path: PathBuf,
+        prv_key_path: PathBuf,
+        in_pek: Option<PathBuf>,
+        out_pek: Option<PathBuf>,
+    ) -> Result<()> {
         let mut out = Cursor::new(Vec::new());
-       
+
         let cert = File::open(oca_path.clone())
             .context(format!("failed to open {}", oca_path.display()))
             .and_then(|mut f| Certificate::decode(&mut f, ()).context("failed to decode OCA"))?;
@@ -581,11 +593,12 @@ mod provision {
             None => {
                 let mut fw = firmware()?;
                 fw.pek_csr()
-                .map_err(|e| anyhow::anyhow!(format!("{:?}", e)))
-                .context("cross signing request failed")?
+                    .map_err(|e| anyhow::anyhow!(format!("{:?}", e)))
+                    .context("cross signing request failed")?
             }
-            Some(f) => { let mut file =
-                File::open(f.clone()).context(format!("failed to open {}", f.display()))?;
+            Some(f) => {
+                let mut file =
+                    File::open(f.clone()).context(format!("failed to open {}", f.display()))?;
                 Certificate::decode(&mut file, ()).context("Unable to decode certificate")?
             }
         };
@@ -593,7 +606,7 @@ mod provision {
         prv_key
             .sign(&mut pek)
             .context("failed to sign PEK with OCA private key")?;
-        
+
         match out_pek {
             None => {
                 let mut fw = firmware()?;
@@ -602,22 +615,22 @@ mod provision {
                     .context("failed to import the newly-signed PEK")?;
             }
             Some(f) => {
-                let mut file = File::create(f.clone()).context(format!("failed to open {}", f.display()))?;
-                pek.encode(&mut out, ()).context("Failed to write pek to output file")?;
+                let mut file =
+                    File::create(f.clone()).context(format!("failed to open {}", f.display()))?;
+                pek.encode(&mut out, ())
+                    .context("Failed to write pek to output file")?;
                 file.write_all(&out.into_inner())
                     .context("unable to write output file")?;
             }
         };
-         
+
         Ok(())
     }
 }
 
-
-
 mod addcek {
 
-    use std::{convert::TryFrom};
+    use std::convert::TryFrom;
 
     use super::*;
 
@@ -628,9 +641,9 @@ mod addcek {
         let mut out = Cursor::new(Vec::new());
 
         let url = format!("{}/{}", CEK_SVC, id);
-        let dst_path : PathBuf = match dst {
+        let dst_path: PathBuf = match dst {
             None => PathBuf::try_from("pdh.bin")?,
-            Some(f) => f
+            Some(f) => f,
         };
 
         chain.cek = download_certificate(&url, Usage::CEK)?;
@@ -647,66 +660,65 @@ mod addcek {
     }
 
     fn sev_chain(filename: PathBuf) -> Result<Chain> {
-        let mut file =
-            File::open(filename).context("unable to open SEV certificate chain file")?;
+        let mut file = File::open(filename).context("unable to open SEV certificate chain file")?;
 
         Chain::decode(&mut file, ()).context("unable to decode chain")
     }
 }
 
-//https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/amd/amd_sev_fam17h_model0xh.sbin
-
-
 mod firmware {
     use super::*;
-    
-    use proc_cpuinfo::{CpuInfo};
 
-    const REPO: &str = "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/amd";
+    use proc_cpuinfo::CpuInfo;
 
-    pub fn cmd(dst: PathBuf) -> Result<()> {
+    const REPO: &str =
+        "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/amd/";
+
+    pub fn cmd(dst: Option<PathBuf>) -> Result<()> {
         let cpu = CpuInfo::read()?;
         let cpu_info = cpu.cpu(0).unwrap();
-        let url_specific = format!("{}/amd_sev_fam{:x}h_model{:x}h.sbin", REPO, 
-                    cpu_info.cpu_family().unwrap(),
-                    cpu_info.model().unwrap());
-        let url_family = format!("{}/amd_sev_fam{:x}h_model{:x}xh.sbin", REPO, 
-                    cpu_info.cpu_family().unwrap(),
-                    cpu_info.model().unwrap() / 16);
-        let url_generic = format!("{}/sev.fw", REPO);
-        //need to do it in reverse by ignoring stuff, firmware can be inexistant
-        
-        let mut file = File::create(dst).context("unable to create output file")?;
-        
         let rt = tokio::runtime::Runtime::new().unwrap();
-        
-        match rt.block_on(download(&url_specific)) {
-            Ok(out) => {
-                println!("Find specific firmware version");
-                file.write_all(&out.into_inner()).context("unable to write output file")?; return Ok(());
-            },
-            Err(_err) => {
-                println!("No specific firmware version");
+
+        let names = [
+            //specific model name
+            format!(
+                "amd_sev_fam{:x}h_model{:x}h.sbin",
+                cpu_info.cpu_family().unwrap(),
+                cpu_info.model().unwrap()
+            ),
+            // high byte specific model
+            format!(
+                "amd_sev_fam{:x}h_model{:x}xh.sbin",
+                cpu_info.cpu_family().unwrap(),
+                cpu_info.model().unwrap() / 16
+            ),
+            //generic model
+            format!("sev.fw"),
+        ];
+
+        for name in names.iter() {
+            match rt.block_on(download(&format!("{}/{}", REPO, name))) {
+                Ok(out) => {
+                    return save_firmware(out, name, dst);
+                }
+                Err(_err) => {
+                    println!("Could not find firmware for {}", name);
+                }
             }
         }
-        match rt.block_on(download(&url_family)) {
-            Ok(out) => {
-                println!("Find family firmware version");
-                file.write_all(&out.into_inner()).context("unable to write output file")?; return Ok(());
-            },
-            Err(_err) => {
-                println!("No less firmware version, this should never happens");
-            }
-        }
-        match rt.block_on(download(&url_generic)) {
-            Ok(out) => {
-                println!("Find generic firmware version");
-                file.write_all(&out.into_inner()).context("unable to write output file")?; return Ok(());
-            },
-            Err(_err) => {
-                println!("No generic firmware, this should happens, amd doesn't provide generic version");
-            }
-        }
+
         Ok(())
+    }
+
+    fn save_firmware(out: Cursor<Vec<u8>>, name: &String, dst: Option<PathBuf>) -> Result<()> {
+        println!("Find firmware version {}", name);
+        let mut file = File::create(match dst {
+            Some(dst_file) => dst_file,
+            None => PathBuf::from(name),
+        }).context("unable to create output file")?;
+
+        file.write_all(&out.into_inner())
+            .context("unable to write output file")?;
+        return Ok(());
     }
 }


### PR DESCRIPTION
- add `Addcek` command to add the CEK certificate to a certificate chain given by the PSP, using the given id
- add `Firmware` command to retrieve the last firmware version depending on the current cpu, using the cpuid crate
- add options to `Generate` command to use given certificate, and not linux ioctl
- rework the download utility function to download firmwares files

